### PR TITLE
Fix Fabric logo link ...for now

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,10 @@ const App: React.FunctionComponent = () => {
       gap={15}
     >
       <img
-        src="https://raw.githubusercontent.com/Microsoft/just/master/packages/just-stack-uifabric/template/src/components/fabric.png"
+        src={
+          "https://raw.githubusercontent.com/microsoft/just/master" +
+          "/packages/just-stack-uifabric/plop-templates/src/fabric.png"
+        }
         alt="logo"
       />
       <Text variant="xxLarge" styles={boldStyle}>


### PR DESCRIPTION
Update the Fabric logo link since the link referenced here is dead. Ideally, and eventually, one would just check this image into this project but it seems like it could use some other upgrades first/more importantly.